### PR TITLE
Use koa response object instead of node's res object

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function c2k (middleware) {
   middleware = connect().use(middleware);
 
   return function * (next) {
-    yield middleware.bind(null, this.req, this.res);
+    yield middleware.bind(null, this.req, this.response);
     yield next;
   }
 


### PR DESCRIPTION
The koa response object is an abstraction on top of node's vanilla response object (i.e. this.res), providing additional functionality e.g. this.redirect
