### PR TITLE
Updates implementation, adds tests, updates package.json and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.log

--- a/README.md
+++ b/README.md
@@ -1,26 +1,31 @@
 # koa-connect
 
-Use connect and express middleware in koa
+Use [Connect](https://github.com/senchalabs/connect)/[Express](https://github.com/strongloop/express) middleware with Koa.
 
-# Install
+It is highly recommended to use Koa middlewares over Connect versions when they're available. That said, this module is a workaround for when that's not an option, and also to remove the need for library authors to write 2 versions of a middleware for their library.
+
+# Installation
 
 ```bash
 npm install koa-connect
 ```
 
-# Usage:
+**Note:** Requires a `Promise` implementation to be installed, either native or polyfilled.
+
+# Usage
+See `examples/` for more real-world examples, or `test/` for some spec examples.
 
 ```javascript
-var koa = require('koa');
-var c2k = require('koa-connect');
-var app = koa();
+const Koa = require('koa');
+const c2k = require('koa-connect');
+const app = new Koa();
 
-function middleware (req, res, next) {
+function connectMiddlware (req, res, next) {
   console.log('connect');
   next();
 }
 
-app.use(c2k(middleware));
+app.use(c2k(connectMiddlware));
 
 app.use(function * () {
   this.body = 'koa';
@@ -29,6 +34,9 @@ app.use(function * () {
 app.listen(3000);
 ```
 
+
+# Testing
+Tests are in the `test/` directory and are made with the [Mocha](https://mochajs.org) framework. You can run them with `npm test` or `npm run test:watch`
 
 # License
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,20 @@
-var connect = require('connect');
-
 function c2k (middleware) {
-  middleware = connect().use(middleware);
+  return function * c2k (next) {
+    // It only takes `req` and `res`, no `next`
+    if (middleware.length === 2) {
+      middleware(this.req, this.res);
+      return;
+    }
 
-  return function * (next) {
-    yield middleware.bind(null, this.req, this.res);
+    // Connect middleware takes `req`, `res`, and `next`
+    yield new Promise((resolve, reject) => {
+      middleware(this.req, this.res, function (err) {
+        if (err) reject(err);
+        else resolve();
+      });
+    })
     yield next;
   }
-
-}
+};
 
 module.exports = c2k;

--- a/package.json
+++ b/package.json
@@ -1,15 +1,27 @@
 {
   "name": "koa-connect",
   "version": "1.0.0",
-  "description": "Use connect and express middleware in koa",
+  "description": "Use Connect/Express middleware in Koa",
   "main": "index.js",
   "author": "Vladimir Kurchatkin <vladimir.kurchatkin@gmail.com>",
-  "respository": "vkurchatkin/koa-connect",
+  "repository": "vkurchatkin/koa-connect",
+  "contributors": [
+    "Louis DeScioli <louis.descioli@gmail.com>"
+  ],
+  "scripts": {
+    "test": "mocha",
+    "test:watch": "mocha --watch --reporter min"
+  },
   "license": "MIT",
   "devDependencies": {
-    "koa": "^0.10.0"
+    "koa": "^0.10.0",
+    "mocha": "^2.3.4",
+    "supertest": "^1.1.0"
   },
-  "dependencies": {
-    "connect": "^2.25.7"
-  }
+  "keywords": [
+    "koa",
+    "connect",
+    "express",
+    "middleware"
+  ]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const Koa = require('koa');
+const supertest = require('supertest');
+const c2k = require('..');
+
+describe('koa-connect', () => {
+  let app;
+
+  beforeEach(() => {
+    app = new Koa();
+    app.use( function * (next) {
+      this.status = 404;
+      this.body = 'Original';
+      yield next;
+    })
+  });
+
+  it('works with a single noop Connect middleware', (done) => {
+    app.use(c2k((req, res, next) => {
+      next()
+    }));
+    supertest(app.callback())
+      .get('/')
+      .expect('Original')
+      .end(done);
+  });
+
+  it('works with two noop Connect middleware', (done) => {
+    app.use(c2k((req, res, next) => next()));
+    app.use(c2k((req, res, next) => next()));
+    supertest(app.callback())
+      .get('/')
+      .expect('Original')
+      .end(done);
+  });
+
+  it('passes correctly to downstream Koa middlewares', (done) => {
+    app.use(c2k((req, res, next) => next()));
+    app.use(function * () { this.status = 200; });
+    supertest(app.callback())
+      .get('/')
+      .expect(200)
+      .end(done);
+  });
+
+  it('bubbles back to earlier middleware', (done) => {
+    app.use(function * (next) {
+      yield next;
+      // Ensures that the following middleware is reached
+      if ( this.status !== 200 ) {
+        done(new Error('Never reached connect middleware'))
+      }
+      this.status = 201;
+    });
+
+    app.use(c2k((req, res) => res.statusCode = 200 ));
+
+    supertest(app.callback())
+      .get('/')
+      .expect(201)
+      .end(done);
+  });
+
+  it('receives errors from Connect middleware', (done) => {
+    app.use(function * (next) {
+      try {
+        yield next;
+      } catch (err) {
+        this.status = 500;
+      }
+    })
+
+    app.use(c2k((req, res, next) => {
+      next(new Error('How Connect does error handling'));
+    }));
+
+    app.use(function * () {
+      // Fail the test if this is reached
+      done(new Error('Improper error handling'))
+    })
+
+    supertest(app.callback())
+      .get('/')
+      .expect(500)
+      .end(done);
+  });
+
+  it('Setting the body or status in Koa middlewares does not do anything if res.end was used in a Connect middleware', (done) => {
+    const message = 'The message that makes it';
+    app.use(function * (next) {
+      yield next;
+      if ( this.status !== 200 ) {
+        done(new Error('Never reached connect middleware'));
+      }
+      // These calls won't end up doing anything
+      // And will cause Koa to log a "Can't set headers after they are sent" error
+      this.status = 500;
+      this.body = 'A story already written';
+    });
+
+    app.use(c2k((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('Content-Length', message.length)
+      res.end(message);
+    }));
+
+    supertest(app.callback())
+      .get('/')
+      .expect(200)
+      .expect(message)
+      .end(done);
+  });
+})


### PR DESCRIPTION
My other pull request (#2) added a bunch of stuff that was just for Koa v2. I figured a better place to start would be for pre-v2 and then we can update the lib for that later.

This changes the basic implementation of the library, but I'm not so sure that it was working before. Welcome to your thoughts and learning why I may be wrong, though.
- Adds tests in test/index.js. I'm not so sure this package was working
  before as none of the tests were passing. I altered the implementation
  where they are now, though. It's a bit hacky checking `function.length`
  and doing different things based on number of args the function accepts,
  but it works
- Fixes typo in package.json and adds keywords
- Removes `connect` dependency. I'm not sure what it was doing, I don't
  believe it was needed
- Updates README with some more information
- Adds myself as a contributor
